### PR TITLE
outline

### DIFF
--- a/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection.sln
+++ b/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32819.101
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitFaster.Caching.DependencyInjection", "BitFaster.Caching.DependencyInjection\BitFaster.Caching.DependencyInjection.csproj", "{337F4327-E35A-40F6-8A6C-7FA47A962D49}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{337F4327-E35A-40F6-8A6C-7FA47A962D49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{337F4327-E35A-40F6-8A6C-7FA47A962D49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{337F4327-E35A-40F6-8A6C-7FA47A962D49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{337F4327-E35A-40F6-8A6C-7FA47A962D49}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {444CBAA7-C7F1-4332-9162-9D98701D3883}
+	EndGlobalSection
+EndGlobal

--- a/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection.csproj
+++ b/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection.csproj
+++ b/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection.csproj
@@ -4,4 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="BitFaster.Caching" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
+  </ItemGroup>
+
 </Project>

--- a/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection/CacheExtensions.cs
+++ b/BitFaster.Caching.DependencyInjection/BitFaster.Caching.DependencyInjection/CacheExtensions.cs
@@ -1,0 +1,40 @@
+﻿using BitFaster.Caching.Lfu;
+using BitFaster.Caching.Lru;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+
+namespace BitFaster.Caching.DependencyInjection
+{
+    /// <summary>
+    /// Extension methods for setting up caches in an <see cref="IServiceCollection" />.
+    /// </summary>
+    public static class CacheExtensions
+    {
+        /// <summary>
+        /// Adds a <see cref="ConcurrentLru{K,V}" />to the <see cref="IServiceCollection" />.
+        /// </summary>
+        /// <typeparam name="K">The type of the key.</typeparam>
+        /// <typeparam name="V">The type of the values.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <param name="configure">A delegate which can use a cache builder to build a cache.</param>
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddConcurrentLru<K, V>(this IServiceCollection services, Action<ConcurrentLruBuilder<K, V>> configure)
+        {
+            // this is not so simple because the builder can change the return type.
+
+            var builder = new ConcurrentLruBuilder<K, V>();
+            configure(builder);
+            services.TryAddSingleton<ICache<K, V>>(builder.Build());
+            return services;
+        }
+
+        public static IServiceCollection AddConcurrentLfu<K, V>(this IServiceCollection services, Action<ConcurrentLfuBuilder<K, V>> configure)
+        {
+            var builder = new ConcurrentLfuBuilder<K, V>();
+            configure(builder);
+            services.TryAddSingleton<ICache<K, V>>(builder.Build());
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
Enables basic use like this:

```cs
services.AddConcurrentLfu<Key, Value>(builder => 
{
    builder
        .WithCapacity(8192)
        .WithScheduler(new BackgroundThreadScheduler())
        .WithKeyComparer(new KeyComparer());
});
```

However, this might not be great because you can still chain on .AsAsyncCache etc. If you do this, it has no effect since the builder instance is changed (since the AddConcurrentLfu method holds a reference to what was passed in, not the resulting object). This is kind of confusing.